### PR TITLE
feat: add basic chat history handling

### DIFF
--- a/src/main/java/de/fau/wisochatbot/chat/ChatController.java
+++ b/src/main/java/de/fau/wisochatbot/chat/ChatController.java
@@ -17,8 +17,11 @@ public class ChatController {
         this.llmService = llmService;
     }
 
-    public record ChatRequest(String message) {}
-    public record ChatResponse(String reply) {}
+    public record ChatRequest(String message) {
+    }
+
+    public record ChatResponse(String reply) {
+    }
 
     @PostMapping("/chat")
     public ChatResponse chat(@RequestBody ChatRequest req, HttpSession session) {
@@ -44,13 +47,16 @@ public class ChatController {
         // Antwort zur History hinzufügen
         history.add(Map.of("role", "assistant", "content", answer));
 
-        // History begrenzen (optional aber wichtig)
-        int maxMessages = 20;
-        if (history.size() > maxMessages) {
-            List<Map<String, String>> trimmed = new ArrayList<>();
-            trimmed.add(history.get(0)); // System behalten
-            trimmed.addAll(history.subList(history.size() - (maxMessages - 1), history.size()));
-            history = trimmed;
+        int maxHistorySize = 21; // 1 System + 20 letzte Nachrichten
+
+        if (history.size() > maxHistorySize) {
+            Map<String, String> system = history.get(0);
+
+            List<Map<String, String>> lastMessages = history.subList(history.size() - 20, history.size());
+
+            history = new ArrayList<>();
+            history.add(system);
+            history.addAll(lastMessages);
         }
 
         session.setAttribute("history", history);

--- a/src/main/java/de/fau/wisochatbot/chat/ChatController.java
+++ b/src/main/java/de/fau/wisochatbot/chat/ChatController.java
@@ -1,26 +1,65 @@
 package de.fau.wisochatbot.chat;
 
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-// src/main/java/.../ChatController.java
+import jakarta.servlet.http.HttpSession;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 @RestController
 @RequestMapping("/api")
 public class ChatController {
 
-  private final LlmService llmService;
+    private final LlmService llmService;
 
-  public ChatController(LlmService llmService) {
-    this.llmService = llmService;
-  }
+    public ChatController(LlmService llmService) {
+        this.llmService = llmService;
+    }
 
-  public record ChatRequest(String message) {}
-  public record ChatResponse(String reply) {}
+    public record ChatRequest(String message) {}
+    public record ChatResponse(String reply) {}
 
-  @PostMapping("/chat")
-  public ChatResponse chat(@RequestBody ChatRequest req) {
-    String answer = llmService.reply(req.message());
-    return new ChatResponse(answer);
-  }
+    @PostMapping("/chat")
+    public ChatResponse chat(@RequestBody ChatRequest req, HttpSession session) {
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, String>> history =
+                (List<Map<String, String>>) session.getAttribute("history");
+
+        if (history == null) {
+            history = new ArrayList<>();
+            history.add(Map.of(
+                    "role", "system",
+                    "content", "Du bist der WiSo-Chatbot. Antworte kurz und hilfreich auf Deutsch."
+            ));
+        }
+
+        // User Nachricht hinzufügen
+        history.add(Map.of("role", "user", "content", req.message()));
+
+        // LLM mit kompletter History aufrufen
+        String answer = llmService.replyWithHistory(history);
+
+        // Antwort zur History hinzufügen
+        history.add(Map.of("role", "assistant", "content", answer));
+
+        // History begrenzen (optional aber wichtig)
+        int maxMessages = 20;
+        if (history.size() > maxMessages) {
+            List<Map<String, String>> trimmed = new ArrayList<>();
+            trimmed.add(history.get(0)); // System behalten
+            trimmed.addAll(history.subList(history.size() - (maxMessages - 1), history.size()));
+            history = trimmed;
+        }
+
+        session.setAttribute("history", history);
+
+        return new ChatResponse(answer);
+    }
+
+    @PostMapping("/chat/reset")
+    public void reset(HttpSession session) {
+        session.removeAttribute("history");
+    }
 }


### PR DESCRIPTION
rework LLM Service to ensure the chat history is considered before answering

current limit is set to 20 (+1 instruction opener) messages saved in local memory of the bot