### PR TITLE
feat: add ratelimiter

### DIFF
--- a/wiso-rag-service/index.html
+++ b/wiso-rag-service/index.html
@@ -370,6 +370,11 @@
         body: JSON.stringify({ message: text, history: getRecentHistory(3) })
       }).then(function(res) {
         removeTypingIndicator();
+        if (res.status === 429) {
+          return res.json().then(function(data) {
+            addMessage('bot', data.reply || 'Zu viele Anfragen. Bitte warte kurz.');
+          });
+        }
         if (!res.ok) {
           addMessage('bot', 'Fehler: HTTP ' + res.status);
           return;

--- a/wiso-rag-service/main.py
+++ b/wiso-rag-service/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, Query, Request
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from typing import Optional
 import chromadb
@@ -6,6 +7,7 @@ import os
 import time
 import re
 import json
+from collections import defaultdict
 from datetime import datetime, timezone
 from rank_bm25 import BM25Okapi
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,6 +17,46 @@ from openai import OpenAI
 
 app = FastAPI()
 app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["*"], allow_headers=["*"])
+
+# --- Rate Limiting ---
+RATE_LIMIT_MAX = int(os.getenv("RATE_LIMIT_MAX", "20"))  # requests per window
+RATE_LIMIT_WINDOW = int(os.getenv("RATE_LIMIT_WINDOW", "60"))  # seconds
+
+class RateLimiter:
+    """Simple in-memory IP-based rate limiter."""
+    def __init__(self):
+        self.requests = defaultdict(list)  # ip -> [timestamps]
+
+    def is_allowed(self, ip: str) -> bool:
+        now = time.time()
+        # Clean old entries
+        self.requests[ip] = [t for t in self.requests[ip] if now - t < RATE_LIMIT_WINDOW]
+        if len(self.requests[ip]) >= RATE_LIMIT_MAX:
+            return False
+        self.requests[ip].append(now)
+        return True
+
+    def remaining(self, ip: str) -> int:
+        now = time.time()
+        self.requests[ip] = [t for t in self.requests[ip] if now - t < RATE_LIMIT_WINDOW]
+        return max(0, RATE_LIMIT_MAX - len(self.requests[ip]))
+
+rate_limiter = RateLimiter()
+
+def get_client_ip(request: Request) -> str:
+    """Get client IP, respecting Cloudflare headers."""
+    cf_ip = request.headers.get("cf-connecting-ip")
+    if cf_ip:
+        return cf_ip
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+RATE_LIMIT_REPLY = (
+    "Du hast zu viele Nachrichten in kurzer Zeit geschickt. "
+    "Bitte warte einen Moment und versuche es dann erneut."
+)
 
 # --- OpenAI Config ---
 openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
@@ -469,7 +511,15 @@ def build_debug(debug_chunks, top_score, verdict, retrieval_ms, llm_ms=0, rewrit
     return d
 
 @app.post("/chat")
-def chat(req: ChatRequest, debug: bool = Query(default=False)):
+def chat(req: ChatRequest, request: Request, debug: bool = Query(default=False)):
+    # Rate limit check
+    client_ip = get_client_ip(request)
+    if not rate_limiter.is_allowed(client_ip):
+        return JSONResponse(
+            status_code=429,
+            content={"reply": RATE_LIMIT_REPLY, "rate_limited": True}
+        )
+
     history = req.history or []
     message_id = generate_message_id()
 
@@ -540,7 +590,15 @@ def chat(req: ChatRequest, debug: bool = Query(default=False)):
 
 # --- Streaming Chat (SSE) ---
 @app.post("/chat/stream")
-def chat_stream(req: ChatRequest):
+def chat_stream(req: ChatRequest, request: Request):
+    # Rate limit check
+    client_ip = get_client_ip(request)
+    if not rate_limiter.is_allowed(client_ip):
+        def rate_limited():
+            yield f"data: {json.dumps({'type': 'token', 'content': RATE_LIMIT_REPLY})}\n\n"
+            yield f"data: {json.dumps({'type': 'done', 'mode': 'RATE_LIMITED'})}\n\n"
+        return StreamingResponse(rate_limited(), media_type="text/event-stream")
+
     history = req.history or []
     message_id = generate_message_id()
 

--- a/wiso-rag-service/tests/test_rate_limit.py
+++ b/wiso-rag-service/tests/test_rate_limit.py
@@ -1,0 +1,82 @@
+"""
+Rate Limit Test — sends rapid requests to verify the limiter works.
+
+Usage:
+  python test_rate_limit.py                          # Against live
+  python test_rate_limit.py --url http://localhost:8000  # Against local
+"""
+
+import time
+import argparse
+
+try:
+    import requests
+except ImportError:
+    import os
+    os.system("pip install requests --break-system-packages -q")
+    import requests
+
+
+def test_rate_limit(api_base, total=25, expected_limit=20):
+    print(f"\nRate Limit Test: sending {total} requests to {api_base}/chat")
+    print(f"Expected: first ~{expected_limit} OK, rest 429\n")
+
+    results = {"ok": 0, "limited": 0, "error": 0}
+
+    for i in range(1, total + 1):
+        try:
+            res = requests.post(
+                f"{api_base}/chat",
+                json={"message": "test"},
+                timeout=10
+            )
+            code = res.status_code
+            if code == 200:
+                results["ok"] += 1
+                status = "OK"
+            elif code == 429:
+                results["limited"] += 1
+                status = "RATE LIMITED"
+            else:
+                results["error"] += 1
+                status = f"ERROR {code}"
+
+            print(f"  [{i:2d}/{total}] {status}")
+
+        except Exception as e:
+            results["error"] += 1
+            print(f"  [{i:2d}/{total}] FAILED: {e}")
+
+    print(f"\nResults:")
+    print(f"  OK (200):       {results['ok']}")
+    print(f"  Limited (429):  {results['limited']}")
+    print(f"  Errors:         {results['error']}")
+
+    # Verify
+    passed = True
+    if results["limited"] == 0:
+        print("\n  FAIL: No requests were rate limited!")
+        passed = False
+    if results["ok"] == 0:
+        print("\n  FAIL: All requests failed!")
+        passed = False
+    if results["ok"] > expected_limit + 2:
+        print(f"\n  FAIL: Too many OK requests ({results['ok']}), expected ~{expected_limit}")
+        passed = False
+
+    if passed:
+        print(f"\n  PASS: Rate limiter works correctly")
+    else:
+        print(f"\n  FAIL: Rate limiter not working as expected")
+
+    return passed
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--url", default="https://chatbot-wiso.de")
+    parser.add_argument("--requests", type=int, default=25)
+    parser.add_argument("--limit", type=int, default=20)
+    args = parser.parse_args()
+
+    test_rate_limit(args.url, args.requests, args.limit)


### PR DESCRIPTION
to prevent spam we decided to add a rate limiter for 20 messages / minute
that should not impact the normal workflow but prevents abuse